### PR TITLE
Evaluate and Transfer Plotting

### DIFF
--- a/src/data_proc.py
+++ b/src/data_proc.py
@@ -21,7 +21,7 @@ class DataProc(torch.utils.data.Dataset):
     def __getitem__(self, item):
         rslt = []
         for i in range(0,len(self.data_dict.keys())):
-            # chose random item based on prop distribution (lenght of each sample)
+            # chose random item based on prop distribution (length of each sample)
             tmp_lens = [j.shape[1] for j in self.data_dict[i]]
             item = np.random.choice(len(tmp_lens),p=tmp_lens/np.sum(tmp_lens))
             rslt.append(self.random_sample(i,item))

--- a/src/data_proc.py
+++ b/src/data_proc.py
@@ -9,7 +9,7 @@ class DataProc(torch.utils.data.Dataset):
 
     def __init__(self, args):
         self.args = args
-        self.data_dict = pickle.load(open('%s/%s.pickle'%(args.dataset, args.model_name),'rb'))
+        self.data_dict = pickle.load(open('%s/data.pickle'%(args.dataset),'rb'))
 
     def __len__(self):
         total_len = 0

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -101,24 +101,14 @@ for i, batch in progress:
     mu1, Z1 = encoder(X1)
     mu2, Z2 = encoder(X2)
 
-    # Reconstruct speech
-    recon_X1 = G1(Z1)
-    recon_X2 = G2(Z2)
-
     # Translate speech
     fake_X1 = G1(Z2)
     fake_X2 = G2(Z1)
-
-    # Cycle translation
-    mu1_, Z1_ = encoder(fake_X1)
-    mu2_, Z2_ = encoder(fake_X2)
-    cycle_X1 = G1(Z2_)
-    cycle_X2 = G2(Z1_)
         
     # Plot batch every couple batch intervals
     if i % opt.plot_interval == 0:
-        plot_batch_eval(opt.model_name, 'plot_A2B', i, X1, recon_X1, fake_X2)
-        plot_batch_eval(opt.model_name, 'plot_B2A', i, X2, recon_X2, fake_X1)
+        plot_batch_eval(opt.model_name, 'plot_A2B', i, X1, fake_X2)
+        plot_batch_eval(opt.model_name, 'plot_B2A', i, X2, fake_X1)
         
     # Append batch output to features dictionary
     feats['A2B'].append([spect for spect in to_numpy(fake_X2)])

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -28,7 +28,7 @@ parser.add_argument("--n_cpu", type=int, default=8, help="number of cpu threads 
 parser.add_argument("--img_height", type=int, default=128, help="size of image height")
 parser.add_argument("--img_width", type=int, default=128, help="size of image width")
 parser.add_argument("--channels", type=int, default=1, help="number of image channels")
-parser.add_argument("--plot_interval", type=int, default=50, help="batch interval between saving generator sample visualisations")
+parser.add_argument("--plot_interval", type=int, default=100, help="batch interval between saving generator sample visualisations")
 parser.add_argument("--n_downsample", type=int, default=2, help="number downsampling layers in encoder")
 parser.add_argument("--dim", type=int, default=32, help="number of filters in first encoder layer")
 
@@ -107,8 +107,8 @@ for i, batch in progress:
         
     # Plot batch every couple batch intervals
     if i % opt.plot_interval == 0:
-        plot_batch_eval(opt.model_name, 'plot_A2B', i, X1, fake_X2)
-        plot_batch_eval(opt.model_name, 'plot_B2A', i, X2, fake_X1)
+        plot_batch_eval(opt.model_name, 'plot_A2B_%s'%opt.epoch, i, X1, fake_X2)
+        plot_batch_eval(opt.model_name, 'plot_B2A_%s'%opt.epoch, i, X2, fake_X1)
         
     # Append batch output to features dictionary
     feats['A2B'].append([spect for spect in to_numpy(fake_X2)])

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -14,7 +14,7 @@ from data_proc import DataProc
 import torch.nn as nn
 import torch
 
-from utils import plot_batch_eval, to_numpy
+from utils import plot_batch_eval, wav_batch_eval, to_numpy
 from collections import defaultdict
 import pickle
 
@@ -28,7 +28,8 @@ parser.add_argument("--n_cpu", type=int, default=8, help="number of cpu threads 
 parser.add_argument("--img_height", type=int, default=128, help="size of image height")
 parser.add_argument("--img_width", type=int, default=128, help="size of image width")
 parser.add_argument("--channels", type=int, default=1, help="number of image channels")
-parser.add_argument("--plot_interval", type=int, default=100, help="batch interval between saving generator sample visualisations")
+parser.add_argument("--plot_interval", type=int, default=100, help="batch interval between plots (set to -1 to disable)")
+parser.add_argument("--wav_interval", type=int, default=200, help="batch interval between wav vocoded from Griffin Lim (set to -1 to disable)")
 parser.add_argument("--n_downsample", type=int, default=2, help="number downsampling layers in encoder")
 parser.add_argument("--dim", type=int, default=32, help="number of filters in first encoder layer")
 
@@ -38,8 +39,12 @@ print(opt)
 cuda = True if torch.cuda.is_available() else False
 
 # Create inference output directories for both transfer directions
-os.makedirs("out_eval/%s/plot_A2B/" % opt.model_name, exist_ok=True)
-os.makedirs("out_eval/%s/plot_B2A/" % opt.model_name, exist_ok=True)
+if opt.plot_interval != -1:
+    os.makedirs("out_eval/%s/plot_A2B_%s/" % (opt.model_name, opt.epoch), exist_ok=True)
+    os.makedirs("out_eval/%s/plot_B2A_%s/" % (opt.model_name, opt.epoch), exist_ok=True)
+if opt.wav_interval != -1:
+    os.makedirs("out_eval/%s/wav_A2B_%s/" % (opt.model_name, opt.epoch), exist_ok=True)
+    os.makedirs("out_eval/%s/wav_B2A_%s/" % (opt.model_name, opt.epoch), exist_ok=True)
 
 input_shape = (opt.channels, opt.img_height, opt.img_width)
 
@@ -106,9 +111,14 @@ for i, batch in progress:
     fake_X2 = G2(Z1)
         
     # Plot batch every couple batch intervals
-    if i % opt.plot_interval == 0:
-        plot_batch_eval(opt.model_name, 'plot_A2B_%s'%opt.epoch, i, X1, fake_X2)
-        plot_batch_eval(opt.model_name, 'plot_B2A_%s'%opt.epoch, i, X2, fake_X1)
+    if opt.plot_interval != -1 and i % opt.plot_interval == 0:
+        plot_batch_eval(opt.model_name, 'plot_A2B_%02d'%opt.epoch, i, X1, fake_X2)
+        plot_batch_eval(opt.model_name, 'plot_B2A_%02d'%opt.epoch, i, X2, fake_X1)
+        
+    # Vocode batch every couple batch intervals    
+    if opt.wav_interval != -1 and i % opt.wav_interval == 0:
+        wav_batch_eval(opt.model_name, 'wav_A2B_%02d'%opt.epoch, i, X1, fake_X2)
+        wav_batch_eval(opt.model_name, 'wav_B2A_%02d'%opt.epoch, i, X2, fake_X1)
         
     # Append batch output to features dictionary
     feats['A2B'].append([spect for spect in to_numpy(fake_X2)])

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -14,7 +14,9 @@ from data_proc import DataProc
 import torch.nn as nn
 import torch
 
-from utils import plot_batch_eval
+from utils import plot_batch_eval, to_numpy
+from collections import defaultdict
+import pickle
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--epoch", type=int, default=0, help="saved version based on epoch to test from")
@@ -26,7 +28,7 @@ parser.add_argument("--n_cpu", type=int, default=8, help="number of cpu threads 
 parser.add_argument("--img_height", type=int, default=128, help="size of image height")
 parser.add_argument("--img_width", type=int, default=128, help="size of image width")
 parser.add_argument("--channels", type=int, default=1, help="number of image channels")
-parser.add_argument("--plot_interval", type=int, default=500, help="batch interval between saving generator sample visualisations")
+parser.add_argument("--plot_interval", type=int, default=50, help="batch interval between saving generator sample visualisations")
 parser.add_argument("--n_downsample", type=int, default=2, help="number downsampling layers in encoder")
 parser.add_argument("--dim", type=int, default=32, help="number of filters in first encoder layer")
 
@@ -55,14 +57,14 @@ if cuda:
     G1 = G1.cuda()
     G2 = G2.cuda()
 
-assert os.path.exists("saved_models/%s/encoder_e%02d.pth" % (opt.model_name, opt.epoch))  # check that trained encoder exists
-assert os.path.exists("saved_models/%s/G1_e%02d.pth" % (opt.model_name, opt.epoch))  # check that trained G1 exists
-assert os.path.exists("saved_models/%s/G2_e%02d.pth" % (opt.model_name, opt.epoch))  # check that trained G2 exists
+assert os.path.exists("saved_models/%s/encoder_%02d.pth" % (opt.model_name, opt.epoch))  # check that trained encoder exists
+assert os.path.exists("saved_models/%s/G1_%02d.pth" % (opt.model_name, opt.epoch))  # check that trained G1 exists
+assert os.path.exists("saved_models/%s/G2_%02d.pth" % (opt.model_name, opt.epoch))  # check that trained G2 exists
     
 # Load pretrained models
-encoder.load_state_dict(torch.load("saved_models/%s/encoder_e%02d.pth" % (opt.model_name, opt.epoch)))
-G1.load_state_dict(torch.load("saved_models/%s/G1_e%02d.pth" % (opt.model_name, opt.epoch)))
-G2.load_state_dict(torch.load("saved_models/%s/G2_e%02d.pth" % (opt.model_name, opt.epoch)))
+encoder.load_state_dict(torch.load("saved_models/%s/encoder_%02d.pth" % (opt.model_name, opt.epoch)))
+G1.load_state_dict(torch.load("saved_models/%s/G1_%02d.pth" % (opt.model_name, opt.epoch)))
+G2.load_state_dict(torch.load("saved_models/%s/G2_%02d.pth" % (opt.model_name, opt.epoch)))
 
 # Set to eval mode 
 encoder.eval()
@@ -78,6 +80,7 @@ dataloader = torch.utils.data.DataLoader(
     pin_memory=True
 )
 
+feats = defaultdict(list)
 
 # ----------
 #  Testing
@@ -117,4 +120,9 @@ for i, batch in progress:
         plot_batch_eval(opt.model_name, 'plot_A2B', i, X1, recon_X1, fake_X2)
         plot_batch_eval(opt.model_name, 'plot_B2A', i, X2, recon_X2, fake_X1)
         
-# TODO: save output in pickle format
+    # Append batch output to features dictionary
+    feats['A2B'].append([spect for spect in to_numpy(fake_X2)])
+    feats['B2A'].append([spect for spect in to_numpy(fake_X1)])
+        
+# Save converted output in pickle format
+pickle.dump(feats,open('out_eval/%s/out.pickle'%(opt.model_name),'wb'))

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -12,11 +12,9 @@ from models import *
 from data_proc import DataProc
 
 import torch.nn as nn
-import torch.nn.functional as F
 import torch
 
 from utils import plot_batch_eval
-
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--epoch", type=int, default=0, help="saved version based on epoch to test from")
@@ -72,9 +70,6 @@ G1.eval()
 G2.eval()
 
 Tensor = torch.cuda.FloatTensor if cuda else torch.Tensor
-
-# Prepare dataloader
-# TODO: Make it so it doesnt do it randomly (for now will just do it randomly)
 dataloader = torch.utils.data.DataLoader(
 	DataProc(opt),
 	batch_size=opt.batch_size,

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -115,4 +115,4 @@ for i, batch in progress:
     feats['B2A'].append([spect for spect in to_numpy(fake_X1)])
         
 # Save converted output in pickle format
-pickle.dump(feats,open('out_eval/%s/out.pickle'%(opt.model_name),'wb'))
+pickle.dump(feats,open('out_eval/%s/out_%s.pickle'%(opt.model_name, opt.epoch),'wb'))

--- a/src/evaluate.py
+++ b/src/evaluate.py
@@ -55,14 +55,14 @@ if cuda:
     G1 = G1.cuda()
     G2 = G2.cuda()
 
-assert os.path.exists("saved_models/%s/encoder_%d.pth" % (opt.model_name, opt.epoch))  # check that trained encoder exists
-assert os.path.exists("saved_models/%s/G1_%d.pth" % (opt.model_name, opt.epoch))  # check that trained G1 exists
-assert os.path.exists("saved_models/%s/G2_%d.pth" % (opt.model_name, opt.epoch))  # check that trained G2 exists
+assert os.path.exists("saved_models/%s/encoder_e%02d.pth" % (opt.model_name, opt.epoch))  # check that trained encoder exists
+assert os.path.exists("saved_models/%s/G1_e%02d.pth" % (opt.model_name, opt.epoch))  # check that trained G1 exists
+assert os.path.exists("saved_models/%s/G2_e%02d.pth" % (opt.model_name, opt.epoch))  # check that trained G2 exists
     
 # Load pretrained models
-encoder.load_state_dict(torch.load("saved_models/%s/encoder_%d.pth" % (opt.model_name, opt.epoch)))
-G1.load_state_dict(torch.load("saved_models/%s/G1_%d.pth" % (opt.model_name, opt.epoch)))
-G2.load_state_dict(torch.load("saved_models/%s/G2_%d.pth" % (opt.model_name, opt.epoch)))
+encoder.load_state_dict(torch.load("saved_models/%s/encoder_e%02d.pth" % (opt.model_name, opt.epoch)))
+G1.load_state_dict(torch.load("saved_models/%s/G1_e%02d.pth" % (opt.model_name, opt.epoch)))
+G2.load_state_dict(torch.load("saved_models/%s/G2_e%02d.pth" % (opt.model_name, opt.epoch)))
 
 # Set to eval mode 
 encoder.eval()
@@ -117,4 +117,4 @@ for i, batch in progress:
         plot_batch_eval(opt.model_name, 'plot_A2B', i, X1, recon_X1, fake_X2)
         plot_batch_eval(opt.model_name, 'plot_B2A', i, X2, recon_X2, fake_X1)
         
-    # TODO: save output in pickle format
+# TODO: save output in pickle format

--- a/src/models.py
+++ b/src/models.py
@@ -53,7 +53,7 @@ class ResidualBlock(nn.Module):
 
 
 class Encoder(nn.Module):
-    def __init__(self, in_channels=3, dim=64, n_downsample=2, shared_block=None):
+    def __init__(self, in_channels=3, dim=64, n_downsample=2, final_block=None):
         super(Encoder, self).__init__()
 
         # Initial convolution block
@@ -78,7 +78,7 @@ class Encoder(nn.Module):
             layers += [ResidualBlock(dim)]
 
         self.model_blocks = nn.Sequential(*layers)
-        self.shared_block = shared_block
+        self.final_block = final_block
 
     def reparameterization(self, mu):
         Tensor = torch.cuda.FloatTensor if mu.is_cuda else torch.FloatTensor
@@ -87,7 +87,7 @@ class Encoder(nn.Module):
 
     def forward(self, x):
         x = self.model_blocks(x)
-        mu = self.shared_block(x)
+        mu = self.final_block(x)
         z = self.reparameterization(mu)
         return mu, z
 

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -3,19 +3,19 @@ import pickle
 from tqdm import tqdm
 from params import num_samples
 from utils import ls, preprocess_wav, melspectrogram
+from collections import defaultdict
 
 parser = argparse.ArgumentParser()
 parser.add_argument("--model_name", type=str, help="name of the model")
 parser.add_argument("--dataset", type=str, help="path to dataset")
 parser.add_argument("--n_spkrs", type=int, default=2, help="number of speakers for conversion")
 
+feats = defaultdict(list)
 opt = parser.parse_args()
 print(opt)
-feats = {}
 
 for spkr in range(opt.n_spkrs):
     wavs = ls('%s/spkr_%s | grep .wav'%(opt.dataset, spkr+1))
-    feats[spkr] = []
     for i, wav in tqdm(enumerate(wavs), total=len(wavs), desc="spkr_%d"%(spkr+1)):
         sample = preprocess_wav('%s/spkr_%s/%s'%(opt.dataset, spkr+1, wav))
         spect = melspectrogram(sample)

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -22,4 +22,4 @@ for spkr in range(opt.n_spkrs):
         if spect.shape[1] >= num_samples:
             feats[spkr].append(spect)
 
-pickle.dump(feats,open('%s/%s.pickle'%(opt.dataset, opt.model_name),'wb'))
+pickle.dump(feats,open('%s/data.pickle'%(opt.dataset),'wb'))

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -14,7 +14,7 @@ feats = defaultdict(list)
 opt = parser.parse_args()
 print(opt)
 
-assert opt != 2, 'Currently only two speakers are supported'
+assert opt.n_spkrs == 2, 'Currently only two speakers are supported'
 
 for spkr in range(opt.n_spkrs):
     wavs = ls('%s/spkr_%s | grep .wav'%(opt.dataset, spkr+1))

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -14,6 +14,8 @@ feats = defaultdict(list)
 opt = parser.parse_args()
 print(opt)
 
+assert opt == 2, 'Currently only two speakers are supported'
+
 for spkr in range(opt.n_spkrs):
     wavs = ls('%s/spkr_%s | grep .wav'%(opt.dataset, spkr+1))
     for i, wav in tqdm(enumerate(wavs), total=len(wavs), desc="spkr_%d"%(spkr+1)):

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -14,7 +14,7 @@ feats = defaultdict(list)
 opt = parser.parse_args()
 print(opt)
 
-assert opt == 2, 'Currently only two speakers are supported'
+assert opt != 2, 'Currently only two speakers are supported'
 
 for spkr in range(opt.n_spkrs):
     wavs = ls('%s/spkr_%s | grep .wav'%(opt.dataset, spkr+1))

--- a/src/train.py
+++ b/src/train.py
@@ -77,11 +77,11 @@ if cuda:
 
 if opt.epoch != 0:
     # Load pretrained models
-    encoder.load_state_dict(torch.load("saved_models/%s/encoder_e%02d.pth" % (opt.model_name, opt.epoch)))
-    G1.load_state_dict(torch.load("saved_models/%s/G1_e%02d.pth" % (opt.model_name, opt.epoch)))
-    G2.load_state_dict(torch.load("saved_models/%s/G2_e%02d.pth" % (opt.model_name, opt.epoch)))
-    D1.load_state_dict(torch.load("saved_models/%s/D1_e%02d.pth" % (opt.model_name, opt.epoch)))
-    D2.load_state_dict(torch.load("saved_models/%s/D2_e%02d.pth" % (opt.model_name, opt.epoch)))
+    encoder.load_state_dict(torch.load("saved_models/%s/encoder_%02d.pth" % (opt.model_name, opt.epoch)))
+    G1.load_state_dict(torch.load("saved_models/%s/G1_%02d.pth" % (opt.model_name, opt.epoch)))
+    G2.load_state_dict(torch.load("saved_models/%s/G2_%02d.pth" % (opt.model_name, opt.epoch)))
+    D1.load_state_dict(torch.load("saved_models/%s/D1_%02d.pth" % (opt.model_name, opt.epoch)))
+    D2.load_state_dict(torch.load("saved_models/%s/D2_%02d.pth" % (opt.model_name, opt.epoch)))
 else:
     # Initialize weights
     encoder.apply(weights_init_normal)
@@ -240,8 +240,7 @@ for epoch in range(opt.epoch, opt.n_epochs):
         losses['G'].append(loss_G.item())
         losses['D'].append((loss_D1 + loss_D2).item())
 
-        # update progress bar
-
+        # Update progress bar
         progress.set_description("[Epoch %d/%d] [D loss: %f] [G loss: %f] "
             % (epoch,opt.n_epochs,np.mean(losses['D']), np.mean(losses['G'])))
         
@@ -257,8 +256,8 @@ for epoch in range(opt.epoch, opt.n_epochs):
 
     if opt.checkpoint_interval != -1 and epoch % opt.checkpoint_interval == 0:
         # Save model checkpoints
-        torch.save(encoder.state_dict(), "saved_models/%s/encoder_e%02d.pth" % (opt.model_name, epoch))
-        torch.save(G1.state_dict(), "saved_models/%s/G1_e%02d.pth" % (opt.model_name, epoch))
-        torch.save(G2.state_dict(), "saved_models/%s/G2_e%02d.pth" % (opt.model_name, epoch))
-        torch.save(D1.state_dict(), "saved_models/%s/D1_e%02d.pth" % (opt.model_name, epoch))
-        torch.save(D2.state_dict(), "saved_models/%s/D2_e%02d.pth" % (opt.model_name, epoch))
+        torch.save(encoder.state_dict(), "saved_models/%s/encoder_%02d.pth" % (opt.model_name, epoch))
+        torch.save(G1.state_dict(), "saved_models/%s/G1_%02d.pth" % (opt.model_name, epoch))
+        torch.save(G2.state_dict(), "saved_models/%s/G2_%02d.pth" % (opt.model_name, epoch))
+        torch.save(D1.state_dict(), "saved_models/%s/D1_%02d.pth" % (opt.model_name, epoch))
+        torch.save(D2.state_dict(), "saved_models/%s/D2_%02d.pth" % (opt.model_name, epoch))

--- a/src/train.py
+++ b/src/train.py
@@ -245,7 +245,7 @@ for epoch in range(opt.epoch, opt.n_epochs):
         progress.set_description("[Epoch %d/%d] [D loss: %f] [G loss: %f] "
             % (epoch,opt.n_epochs,np.mean(losses['D']), np.mean(losses['G'])))
         
-        # Plot transfer images of the first batch every epoch or few epochs
+        # Plot first batch every epoch or few epochs
         if epoch % opt.plot_interval == 0 and i == 0:
             plot_batch_train(opt.model_name, 'plot_A2B', epoch, X1, recon_X1, fake_X2, X2)
             plot_batch_train(opt.model_name, 'plot_B2A', epoch, X2, recon_X2, fake_X1, X1)

--- a/src/train.py
+++ b/src/train.py
@@ -77,11 +77,11 @@ if cuda:
 
 if opt.epoch != 0:
     # Load pretrained models
-    encoder.load_state_dict(torch.load("saved_models/%s/encoder_%d.pth" % (opt.model_name, opt.epoch)))
-    G1.load_state_dict(torch.load("saved_models/%s/G1_%d.pth" % (opt.model_name, opt.epoch)))
-    G2.load_state_dict(torch.load("saved_models/%s/G2_%d.pth" % (opt.model_name, opt.epoch)))
-    D1.load_state_dict(torch.load("saved_models/%s/D1_%d.pth" % (opt.model_name, opt.epoch)))
-    D2.load_state_dict(torch.load("saved_models/%s/D2_%d.pth" % (opt.model_name, opt.epoch)))
+    encoder.load_state_dict(torch.load("saved_models/%s/encoder_e%02d.pth" % (opt.model_name, opt.epoch)))
+    G1.load_state_dict(torch.load("saved_models/%s/G1_e%02d.pth" % (opt.model_name, opt.epoch)))
+    G2.load_state_dict(torch.load("saved_models/%s/G2_e%02d.pth" % (opt.model_name, opt.epoch)))
+    D1.load_state_dict(torch.load("saved_models/%s/D1_e%02d.pth" % (opt.model_name, opt.epoch)))
+    D2.load_state_dict(torch.load("saved_models/%s/D2_e%02d.pth" % (opt.model_name, opt.epoch)))
 else:
     # Initialize weights
     encoder.apply(weights_init_normal)

--- a/src/train.py
+++ b/src/train.py
@@ -257,8 +257,8 @@ for epoch in range(opt.epoch, opt.n_epochs):
 
     if opt.checkpoint_interval != -1 and epoch % opt.checkpoint_interval == 0:
         # Save model checkpoints
-        torch.save(encoder.state_dict(), "saved_models/%s/encoder_%02d.pth" % (opt.model_name, epoch))
-        torch.save(G1.state_dict(), "saved_models/%s/G1_%02d.pth" % (opt.model_name, epoch))
-        torch.save(G2.state_dict(), "saved_models/%s/G2_%02d.pth" % (opt.model_name, epoch))
-        torch.save(D1.state_dict(), "saved_models/%s/D1_%02d.pth" % (opt.model_name, epoch))
-        torch.save(D2.state_dict(), "saved_models/%s/D2_%02d.pth" % (opt.model_name, epoch))
+        torch.save(encoder.state_dict(), "saved_models/%s/encoder_e%02d.pth" % (opt.model_name, epoch))
+        torch.save(G1.state_dict(), "saved_models/%s/G1_e%02d.pth" % (opt.model_name, epoch))
+        torch.save(G2.state_dict(), "saved_models/%s/G2_e%02d.pth" % (opt.model_name, epoch))
+        torch.save(D1.state_dict(), "saved_models/%s/D1_e%02d.pth" % (opt.model_name, epoch))
+        torch.save(D2.state_dict(), "saved_models/%s/D2_e%02d.pth" % (opt.model_name, epoch))

--- a/src/train.py
+++ b/src/train.py
@@ -32,7 +32,7 @@ parser.add_argument("--n_cpu", type=int, default=8, help="number of cpu threads 
 parser.add_argument("--img_height", type=int, default=128, help="size of image height")
 parser.add_argument("--img_width", type=int, default=128, help="size of image width")
 parser.add_argument("--channels", type=int, default=1, help="number of image channels")
-parser.add_argument("--plot_interval", type=int, default=1, help="epoch interval between saving generator sample visualisations")
+parser.add_argument("--plot_interval", type=int, default=1, help="epoch interval between saving plots (disable with -1)")
 parser.add_argument("--checkpoint_interval", type=int, default=1, help="interval between saving model checkpoints")
 parser.add_argument("--n_downsample", type=int, default=2, help="number downsampling layers in encoder")
 parser.add_argument("--dim", type=int, default=32, help="number of filters in first encoder layer")
@@ -46,8 +46,9 @@ cuda = True if torch.cuda.is_available() else False
 os.makedirs("saved_models/%s" % opt.model_name, exist_ok=True)
 
 # Create plot output directories
-os.makedirs("out_train/%s/plot_A2B/" % opt.model_name, exist_ok=True)
-os.makedirs("out_train/%s/plot_B2A/" % opt.model_name, exist_ok=True)
+if opt.plot_interval != -1:
+    os.makedirs("out_train/%s/plot_A2B/" % opt.model_name, exist_ok=True)
+    os.makedirs("out_train/%s/plot_B2A/" % opt.model_name, exist_ok=True)
 
 # Losses
 criterion_GAN = torch.nn.MSELoss()
@@ -245,7 +246,7 @@ for epoch in range(opt.epoch, opt.n_epochs):
             % (epoch,opt.n_epochs,np.mean(losses['D']), np.mean(losses['G'])))
         
         # Plot first batch every epoch or few epochs
-        if epoch % opt.plot_interval == 0 and i == 0:
+        if opt.plot_interval != -1 and epoch % opt.plot_interval == 0 and i == 0:
             plot_batch_train(opt.model_name, 'plot_A2B', epoch, X1, cycle_X1, fake_X2, X2)
             plot_batch_train(opt.model_name, 'plot_B2A', epoch, X2, cycle_X2, fake_X1, X1)
 

--- a/src/train.py
+++ b/src/train.py
@@ -54,8 +54,7 @@ input_shape = (opt.channels, opt.img_height, opt.img_width)
 shared_dim = opt.dim * 2 ** opt.n_downsample
 
 # Initialize generator and discriminator
-shared_E = ResidualBlock(features=shared_dim)
-encoder = Encoder(dim=opt.dim, in_channels=opt.channels, n_downsample=opt.n_downsample, shared_block=shared_E)
+encoder = Encoder(dim=opt.dim, in_channels=opt.channels, n_downsample=opt.n_downsample, final_block=ResidualBlock(features=shared_dim))
 shared_G = ResidualBlock(features=shared_dim)
 G1 = Generator(dim=opt.dim, out_channels=opt.channels, n_upsample=opt.n_downsample, shared_block=shared_G)
 G2 = Generator(dim=opt.dim, out_channels=opt.channels, n_upsample=opt.n_downsample, shared_block=shared_G)
@@ -121,7 +120,9 @@ dataloader = torch.utils.data.DataLoader(
 	DataProc(opt),
 	batch_size=opt.batch_size,
 	shuffle=True,
-	num_workers=opt.n_cpu)
+	num_workers=opt.n_cpu,
+    pin_memory=True
+)
 
 def compute_kl(mu):
     mu_2 = torch.pow(mu, 2)

--- a/src/train.py
+++ b/src/train.py
@@ -257,8 +257,8 @@ for epoch in range(opt.epoch, opt.n_epochs):
 
     if opt.checkpoint_interval != -1 and epoch % opt.checkpoint_interval == 0:
         # Save model checkpoints
-        torch.save(encoder.state_dict(), "saved_models/%s/encoder_%d.pth" % (opt.model_name, epoch))
-        torch.save(G1.state_dict(), "saved_models/%s/G1_%d.pth" % (opt.model_name, epoch))
-        torch.save(G2.state_dict(), "saved_models/%s/G2_%d.pth" % (opt.model_name, epoch))
-        torch.save(D1.state_dict(), "saved_models/%s/D1_%d.pth" % (opt.model_name, epoch))
-        torch.save(D2.state_dict(), "saved_models/%s/D2_%d.pth" % (opt.model_name, epoch))
+        torch.save(encoder.state_dict(), "saved_models/%s/encoder_%02d.pth" % (opt.model_name, epoch))
+        torch.save(G1.state_dict(), "saved_models/%s/G1_%02d.pth" % (opt.model_name, epoch))
+        torch.save(G2.state_dict(), "saved_models/%s/G2_%02d.pth" % (opt.model_name, epoch))
+        torch.save(D1.state_dict(), "saved_models/%s/D1_%02d.pth" % (opt.model_name, epoch))
+        torch.save(D2.state_dict(), "saved_models/%s/D2_%02d.pth" % (opt.model_name, epoch))

--- a/src/train.py
+++ b/src/train.py
@@ -246,8 +246,8 @@ for epoch in range(opt.epoch, opt.n_epochs):
         
         # Plot first batch every epoch or few epochs
         if epoch % opt.plot_interval == 0 and i == 0:
-            plot_batch_train(opt.model_name, 'plot_A2B', epoch, X1, recon_X1, fake_X2, X2)
-            plot_batch_train(opt.model_name, 'plot_B2A', epoch, X2, recon_X2, fake_X1, X1)
+            plot_batch_train(opt.model_name, 'plot_A2B', epoch, X1, cycle_X1, fake_X2, X2)
+            plot_batch_train(opt.model_name, 'plot_B2A', epoch, X2, cycle_X2, fake_X1, X1)
 
     # Update learning rates
     lr_scheduler_G.step()

--- a/src/utils.py
+++ b/src/utils.py
@@ -253,12 +253,12 @@ def plot_batch_train(modelname, direction, curr_epoch, SRC, cyclic_SRC, fake_TRG
     i = 1
     for src, cyclic_src, fake_target, real_target in zip(SRC, cyclic_SRC, fake_TRGT, real_TRGT):
         fname = "out_train/%s/%s/%s_%03d_%s.png"%(modelname, direction, direction, curr_epoch, i)
-        plot_mel_transfer_train(fname, curr_epoch, src, recon_src, fake_target, real_target)
+        plot_mel_transfer_train(fname, curr_epoch, src, cyclic_src, fake_target, real_target)
         i += 1
     
 def plot_mel_transfer_eval(save_path, mel_in, mel_out):
     """Visualises melspectrogram style transfer in testing, with target implictly learnt"""
-    fig, ax = plt.subplots(nrows=1, ncols=2, sharex=True, figsize=(6,3))
+    fig, ax = plt.subplots(nrows=1, ncols=2, sharex=True, figsize=(5,3))
     
     ax[0].imshow(np.rot90(mel_in, 2), interpolation="None")
     ax[0].set(title='Input')
@@ -270,13 +270,14 @@ def plot_mel_transfer_eval(save_path, mel_in, mel_out):
     ax[1].set_xlabel('Frames')
     ax[1].axes.yaxis.set_ticks([])
 
+    plt.tight_layout()
     plt.savefig(save_path)
     plt.close()
    
     
 def plot_batch_eval(modelname, direction, batchno, SRC, fake_TRGT):
     """Plots all melspectrogram results in a batch with real_TRGT excluded"""
-    SRC, recon_SRC, fake_TRGT = to_numpy(SRC), to_numpy(recon_SRC), to_numpy(fake_TRGT)
+    SRC, fake_TRGT = to_numpy(SRC), to_numpy(fake_TRGT)
     i = 1
     for src, fake_target in zip(SRC, fake_TRGT):
         fname = "out_eval/%s/%s/%s_%04d_%s.png"%(modelname, direction, direction, batchno, i)

--- a/src/utils.py
+++ b/src/utils.py
@@ -248,7 +248,6 @@ def plot_mel_transfer_train(save_path, curr_epoch, mel_in, mel_cyclic, mel_out, 
     plt.close()
     
 def plot_batch_train(modelname, direction, curr_epoch, SRC, cyclic_SRC, fake_TRGT, real_TRGT):
-    """Plots all melspectrogram results in a batch with real_TRGT included"""
     SRC, cyclic_SRC, fake_TRGT, real_TRGT = to_numpy(SRC), to_numpy(cyclic_SRC), to_numpy(fake_TRGT), to_numpy(real_TRGT)
     i = 1
     for src, cyclic_src, fake_target, real_target in zip(SRC, cyclic_SRC, fake_TRGT, real_TRGT):
@@ -257,7 +256,7 @@ def plot_batch_train(modelname, direction, curr_epoch, SRC, cyclic_SRC, fake_TRG
         i += 1
     
 def plot_mel_transfer_eval(save_path, mel_in, mel_out):
-    """Visualises melspectrogram style transfer in testing, with target implictly learnt"""
+    """Visualises melspectrogram style transfer in testing, only shows input and output"""
     fig, ax = plt.subplots(nrows=1, ncols=2, sharex=True, figsize=(5,3))
     
     ax[0].imshow(np.rot90(mel_in, 2), interpolation="None")
@@ -276,7 +275,6 @@ def plot_mel_transfer_eval(save_path, mel_in, mel_out):
    
     
 def plot_batch_eval(modelname, direction, batchno, SRC, fake_TRGT):
-    """Plots all melspectrogram results in a batch with real_TRGT excluded"""
     SRC, fake_TRGT = to_numpy(SRC), to_numpy(fake_TRGT)
     i = 1
     for src, fake_target in zip(SRC, fake_TRGT):
@@ -284,3 +282,18 @@ def plot_batch_eval(modelname, direction, batchno, SRC, fake_TRGT):
         plot_mel_transfer_eval(fname, src, fake_target)
         i += 1
         
+        
+def wav_batch_eval(modelname, direction, batchno, SRC, fake_TRGT):
+    SRC, fake_TRGT = to_numpy(SRC), to_numpy(fake_TRGT)
+    i = 1
+    for src, fake_target in zip(SRC, fake_TRGT):
+        name = "out_eval/%s/%s/%s_%04d_%s"%(modelname, direction, direction, batchno, i)
+        
+        ref = reconstruct_waveform(src)
+        ref_fname = name + '_ref.wav'
+        sf.write(ref_fname, ref, sample_rate)
+        
+        out = reconstruct_waveform(fake_target)
+        out_fname = name + '_out.wav'
+        sf.write(out_fname, out, sample_rate)
+        i += 1

--- a/src/utils.py
+++ b/src/utils.py
@@ -218,7 +218,7 @@ def to_numpy(batch):
     batch = np.squeeze(batch)
     return batch
 
-def plot_mel_transfer_train(save_path, curr_epoch, mel_in, mel_recon, mel_out, mel_target):
+def plot_mel_transfer_train(save_path, curr_epoch, mel_in, mel_cyclic, mel_out, mel_target):
     """Visualises melspectrogram style transfer in training, with target specified"""
     fig, ax = plt.subplots(nrows=2, ncols=2, figsize=(6, 6))
     
@@ -228,8 +228,8 @@ def plot_mel_transfer_train(save_path, curr_epoch, mel_in, mel_recon, mel_out, m
     ax[0,0].axes.xaxis.set_ticks([])
     ax[0,0].axes.xaxis.set_ticks([])
     
-    ax[1,0].imshow(np.rot90(mel_recon, 2), interpolation="None")
-    ax[1,0].set(title='Reconstructed Input')
+    ax[1,0].imshow(np.rot90(mel_cyclic, 2), interpolation="None")
+    ax[1,0].set(title='Cyclic Reconstruction')
     ax[1,0].set_xlabel('Frames')
     ax[1,0].set_ylabel('Mels')
 
@@ -247,42 +247,39 @@ def plot_mel_transfer_train(save_path, curr_epoch, mel_in, mel_recon, mel_out, m
     plt.savefig(save_path)
     plt.close()
     
-def plot_batch_train(modelname, direction, curr_epoch, SRC, recon_SRC, fake_TRGT, real_TRGT):
+def plot_batch_train(modelname, direction, curr_epoch, SRC, cyclic_SRC, fake_TRGT, real_TRGT):
     """Plots all melspectrogram results in a batch with real_TRGT included"""
-    SRC, recon_SRC, fake_TRGT, real_TRGT = to_numpy(SRC), to_numpy(recon_SRC), to_numpy(fake_TRGT), to_numpy(real_TRGT)
+    SRC, cyclic_SRC, fake_TRGT, real_TRGT = to_numpy(SRC), to_numpy(cyclic_SRC), to_numpy(fake_TRGT), to_numpy(real_TRGT)
     i = 1
-    for src, recon_src, fake_target, real_target in zip(SRC, recon_SRC, fake_TRGT, real_TRGT):
+    for src, cyclic_src, fake_target, real_target in zip(SRC, cyclic_SRC, fake_TRGT, real_TRGT):
         fname = "out_train/%s/%s/%s_%03d_%s.png"%(modelname, direction, direction, curr_epoch, i)
         plot_mel_transfer_train(fname, curr_epoch, src, recon_src, fake_target, real_target)
         i += 1
     
-def plot_mel_transfer_eval(save_path, mel_in, mel_recon, mel_out):
+def plot_mel_transfer_eval(save_path, mel_in, mel_out):
     """Visualises melspectrogram style transfer in testing, with target implictly learnt"""
-    fig, ax = plt.subplots(nrows=1, ncols=3, sharex=True, figsize=(6,3))
+    fig, ax = plt.subplots(nrows=1, ncols=2, sharex=True, figsize=(6,3))
     
     ax[0].imshow(np.rot90(mel_in, 2), interpolation="None")
     ax[0].set(title='Input')
     ax[0].set_ylabel('Mels')
-    
-    ax[1].imshow(np.rot90(mel_recon, 2), interpolation="None")
-    ax[1].set(title='Reconstructed Input')
-    ax[1].axes.yaxis.set_ticks([])
+    ax[0].set_xlabel('Frames')
 
-    ax[2].imshow(np.rot90(mel_out, 2), interpolation="None")
-    ax[2].set(title='Output')
-    ax[2].set_xlabel('Frames')
-    ax[2].axes.yaxis.set_ticks([])
+    ax[1].imshow(np.rot90(mel_out, 2), interpolation="None")
+    ax[1].set(title='Output')
+    ax[1].set_xlabel('Frames')
+    ax[1].axes.yaxis.set_ticks([])
 
     plt.savefig(save_path)
     plt.close()
    
     
-def plot_batch_eval(modelname, direction, batchno, SRC, recon_SRC, fake_TRGT):
+def plot_batch_eval(modelname, direction, batchno, SRC, fake_TRGT):
     """Plots all melspectrogram results in a batch with real_TRGT excluded"""
     SRC, recon_SRC, fake_TRGT = to_numpy(SRC), to_numpy(recon_SRC), to_numpy(fake_TRGT)
     i = 1
-    for src, recon_src, fake_target in zip(SRC, recon_SRC, fake_TRGT):
+    for src, fake_target in zip(SRC, fake_TRGT):
         fname = "out_eval/%s/%s/%s_%04d_%s.png"%(modelname, direction, direction, batchno, i)
-        plot_mel_transfer_eval(fname, src, recon_src, fake_target)
+        plot_mel_transfer_eval(fname, src, fake_target)
         i += 1
         

--- a/src/utils.py
+++ b/src/utils.py
@@ -252,13 +252,13 @@ def plot_batch_train(modelname, direction, curr_epoch, SRC, recon_SRC, fake_TRGT
     SRC, recon_SRC, fake_TRGT, real_TRGT = to_numpy(SRC), to_numpy(recon_SRC), to_numpy(fake_TRGT), to_numpy(real_TRGT)
     i = 1
     for src, recon_src, fake_target, real_target in zip(SRC, recon_SRC, fake_TRGT, real_TRGT):
-        fname = "out_train/%s/%s/%s_%02d_%s.png"%(modelname, direction, direction, curr_epoch, i)
+        fname = "out_train/%s/%s/%s_%03d_%s.png"%(modelname, direction, direction, curr_epoch, i)
         plot_mel_transfer_train(fname, curr_epoch, src, recon_src, fake_target, real_target)
         i += 1
     
 def plot_mel_transfer_eval(save_path, mel_in, mel_recon, mel_out):
     """Visualises melspectrogram style transfer in testing, with target implictly learnt"""
-    fig, ax = plt.subplots(nrows=1, ncols=3, sharex=True, figsize=(12,6))
+    fig, ax = plt.subplots(nrows=1, ncols=3, sharex=True, figsize=(6,3))
     
     ax[0].imshow(np.rot90(mel_in, 2), interpolation="None")
     ax[0].set(title='Input')
@@ -282,7 +282,7 @@ def plot_batch_eval(modelname, direction, batchno, SRC, recon_SRC, fake_TRGT):
     SRC, recon_SRC, fake_TRGT = to_numpy(SRC), to_numpy(recon_SRC), to_numpy(fake_TRGT)
     i = 1
     for src, recon_src, fake_target in zip(SRC, recon_SRC, fake_TRGT):
-        fname = "out_eval/%s/%s/%s_%s_%s.png"%(modelname, direction, direction, batchno, i)
+        fname = "out_eval/%s/%s/%s_%04d_%s.png"%(modelname, direction, direction, batchno, i)
         plot_mel_transfer_eval(fname, src, recon_src, fake_target)
         i += 1
         

--- a/src/utils.py
+++ b/src/utils.py
@@ -258,7 +258,7 @@ def plot_batch_train(modelname, direction, curr_epoch, SRC, recon_SRC, fake_TRGT
     
 def plot_mel_transfer_eval(save_path, mel_in, mel_recon, mel_out):
     """Visualises melspectrogram style transfer in testing, with target implictly learnt"""
-    fig, ax = plt.subplots(nrows=1, ncols=3, sharex=True, figsize=(6,3))
+    fig, ax = plt.subplots(nrows=1, ncols=3, sharex=True, figsize=(12,6))
     
     ax[0].imshow(np.rot90(mel_in, 2), interpolation="None")
     ax[0].set(title='Input')

--- a/src/utils.py
+++ b/src/utils.py
@@ -252,7 +252,7 @@ def plot_batch_train(modelname, direction, curr_epoch, SRC, cyclic_SRC, fake_TRG
     SRC, cyclic_SRC, fake_TRGT, real_TRGT = to_numpy(SRC), to_numpy(cyclic_SRC), to_numpy(fake_TRGT), to_numpy(real_TRGT)
     i = 1
     for src, cyclic_src, fake_target, real_target in zip(SRC, cyclic_SRC, fake_TRGT, real_TRGT):
-        fname = "out_train/%s/%s/%s_%03d_%s.png"%(modelname, direction, direction, curr_epoch, i)
+        fname = "out_train/%s/%s/%s_%02d_%s.png"%(modelname, direction, direction, curr_epoch, i)
         plot_mel_transfer_train(fname, curr_epoch, src, cyclic_src, fake_target, real_target)
         i += 1
     

--- a/src/utils.py
+++ b/src/utils.py
@@ -252,7 +252,7 @@ def plot_batch_train(modelname, direction, curr_epoch, SRC, recon_SRC, fake_TRGT
     SRC, recon_SRC, fake_TRGT, real_TRGT = to_numpy(SRC), to_numpy(recon_SRC), to_numpy(fake_TRGT), to_numpy(real_TRGT)
     i = 1
     for src, recon_src, fake_target, real_target in zip(SRC, recon_SRC, fake_TRGT, real_TRGT):
-        fname = "out_train/%s/%s/%s_e%02d_n%s.png"%(modelname, direction, direction, curr_epoch, i)
+        fname = "out_train/%s/%s/%s_%02d_%s.png"%(modelname, direction, direction, curr_epoch, i)
         plot_mel_transfer_train(fname, curr_epoch, src, recon_src, fake_target, real_target)
         i += 1
     
@@ -282,7 +282,7 @@ def plot_batch_eval(modelname, direction, batchno, SRC, recon_SRC, fake_TRGT):
     SRC, recon_SRC, fake_TRGT = to_numpy(SRC), to_numpy(recon_SRC), to_numpy(fake_TRGT)
     i = 1
     for src, recon_src, fake_target in zip(SRC, recon_SRC, fake_TRGT):
-        fname = "out_eval/%s/%s/%s_b_n%s.png"%(modelname, direction, direction, batchno, i)
+        fname = "out_eval/%s/%s/%s_%s_%s.png"%(modelname, direction, direction, batchno, i)
         plot_mel_transfer_eval(fname, src, recon_src, fake_target)
         i += 1
         


### PR DESCRIPTION
# Overview
- Added evaluate.py - purpose to run on a test set without weight updates, and save out.pickle of conversions when done
- Added plotting functionality to both evaluate.py and train.py
- Updated Encoder model definition, removed final_block (shared_block) param
- Updated preprocessing to be with defaultdict(list). Just for less verbosity, and consistency with what I did in evaluate.py for feats dictionary

## Plotting Notes
- In train.py it plots the first batch every epoch or few epochs (specified by plot_interval arg)
- In evaluate.py plot_interval arg controls how often it plots a batch (with respect to every few batches, since no epochs in evaluate)
- The code looks kind of repeated for plotting in utils.py. But figured its more readable this way as opposed to having a single method with lots of conditions. Also, need to separate eval from train plot functions, since train is also concerned with plotting the target used in updating weight - while eval isn't.

### Train Plot
![image](https://user-images.githubusercontent.com/35470600/123918428-c7218680-d97b-11eb-8499-1c96f8fc1c10.png)

### Eval Plot
![image](https://user-images.githubusercontent.com/35470600/123918208-8c1f5300-d97b-11eb-8a0b-106f4fa98fa9.png)