### PR TITLE
Fix outdated requirements.txt, which can lead to errors in training.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,19 @@
-librosa==0.8.1
-matplotlib==3.4.2
-numpy==1.21.1
-scikit_learn==0.24.2
-scipy==1.7.1
-scikit-image
-soundfile==0.10.3.post1
-torch==1.9.0+cu111 
-torchvision==0.10.0+cu111 
-torchaudio==0.9.0
-tqdm==4.62.0
-webrtcvad==2.0.10
+# Dependencies all have to be a specific version for this to work.
+# See https://github.com/ebadawy/voice_conversion/issues/26 for more details.
+
+# Numba needs to be 0.56.4 for this to work.
+# Otherwise, it won't be compatible with numpy 1.23.3.
+numba==0.56.4
+librosa==0.9.2
+matplotlib==3.5.2
+matplotlib-inline==0.1.6
+numpy==1.23.3
+scipy==1.4.1
+scikit-image==0.19.2
+soundfile==0.11.0
+torch==1.12.1
+torchaudio==0.12.1
+torchvision==0.13.1
+torchviz==0.0.2
+tqdm==4.64.0
+webrtcvad-wheels==2.0.11.post1


### PR DESCRIPTION
This is a simple PR, which addresses #26, where I was getting an error during training. After debugging with @magicse, I was able to determine the cause of the issue to be a discrepancy between the ``requirements.txt`` package versions, and what @magicse had working on their device. After fiddling with dependency versions, and dependency-of-dependencies versioning, I was able to fix my issue with the proposed ``requirements.txt``. 

I have also added comments to the ``requirements.txt`` detailing why the specific versions are necessary, as, at face value, it seems that the latest of every package should work. I'm happy to answer any questions about this PR, but since it's a pretty minor "ease-of-use" change, I expect it should be an easy merge.