### PR TITLE
Incorrect input data for librosa.feature.inverse.mel_to_stft

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -211,9 +211,9 @@ def reconstruct_waveform(mel, n_iter=32):
     mel spectrogram back into a waveform."""
     denormalized = denormalize(mel)
     amp_mel = db_to_amp(denormalized)
-    amp_mel = np.square(amp_mel)
+    pow_mel = np.square(amp_mel)
     S = librosa.feature.inverse.mel_to_stft(
-        amp_mel, power=1, sr=sample_rate,
+        pow_mel, power=1, sr=sample_rate,
         n_fft=n_fft, fmin=fmin)
     wav = librosa.core.griffinlim(
         S, n_iter=n_iter,

--- a/src/utils.py
+++ b/src/utils.py
@@ -211,6 +211,7 @@ def reconstruct_waveform(mel, n_iter=32):
     mel spectrogram back into a waveform."""
     denormalized = denormalize(mel)
     amp_mel = db_to_amp(denormalized)
+    amp_mel = np.square(amp_mel)
     S = librosa.feature.inverse.mel_to_stft(
         amp_mel, power=1, sr=sample_rate,
         n_fft=n_fft, fmin=fmin)


### PR DESCRIPTION
Incorrect input data due to which the restored sound contains overtones of vibration and distortion. 
The librosa.feature.inverse.mel_to_stft function takes as input not the amplitude (magnitude) but the power value. 
Accordingly, the formula for power looks like this 
power = magnitude ^ 2